### PR TITLE
fix: copy all options from group

### DIFF
--- a/addon/utils/group-utils.ts
+++ b/addon/utils/group-utils.ts
@@ -94,7 +94,7 @@ export function optionAtIndex(originalCollection: any, index: number): { disable
 
 export interface Group { options: any[], disabled?: boolean, groupName: string }
 function copyGroup(group: Group, suboptions: any[]): Group {
-  let groupCopy: Group = { groupName: group.groupName, options: suboptions };
+  let groupCopy: Group = { ...group, options: suboptions };
   if (group.hasOwnProperty('disabled')) {
     groupCopy.disabled = group.disabled;
   }


### PR DESCRIPTION
## Why?
In our use case of `ember-power-select` we add custom properties onto the groups to conditionally render those groups in a different way (in the `@groupComponent` that we pass to PowerSelectMultiple).

However, because the `copyGroup` function strips those custom properties, our styling is broken as soon as a user enters a search term.

## What?
Change the `copyGroup` function to include all fields.

PR on `cibernox/ember-power-select`: https://github.com/cibernox/ember-power-select/pull/1843